### PR TITLE
Case 2

### DIFF
--- a/src/main/kotlin/ru/quipy/common/utils/FixedWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/FixedWindowRateLimiter.kt
@@ -141,7 +141,7 @@ fun makeRateLimiter(accountName: String, rate: Int, timeUnit: TimeUnit = TimeUni
     val config = RateLimiterConfig.custom()
         .limitRefreshPeriod(if (timeUnit == TimeUnit.SECONDS) Duration.ofSeconds(1) else Duration.ofMinutes(1))
         .limitForPeriod(rate)
-        .timeoutDuration(Duration.ofMillis(5))
+        .timeoutDuration(Duration.ofSeconds(5))
         .build()
 
     val rateLimiterRegistry = RateLimiterRegistry.of(config)

--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/RateLimiterInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/RateLimiterInterceptor.kt
@@ -1,0 +1,16 @@
+package ru.quipy.common.utils.okhttp
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class RateLimiterInterceptor(
+    private val limiter: RateLimiter,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (!limiter.acquirePermission()) throw IOException("Timeout from RateLimiter")
+
+        return chain.proceed(chain.request())
+    }
+}

--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/WindowLimiterInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/WindowLimiterInterceptor.kt
@@ -1,0 +1,18 @@
+package ru.quipy.common.utils.okhttp
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.concurrent.Semaphore
+
+class WindowLimiterInterceptor(limit: Int) : Interceptor {
+    private val semaphore: Semaphore = Semaphore(limit, true)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        try {
+            semaphore.acquire()
+            return chain.proceed(chain.request())
+        } finally {
+            semaphore.release()
+        }
+    }
+}

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -12,4 +12,4 @@ Content-Type: application/json
 
 ### Stop running test to save time and resources
 # @timeout 120
-POST http://localhost:4321/test/stop/"{{serviceName}}"
+POST http://localhost:1234/test/stop/{{serviceName}}

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -16,4 +16,4 @@ Content-Type: application/json
 
 ### Stop running test to save credits
 # @timeout 120
-POST http://77.234.215.138:31234/test/stop/"{{serviceName}}"
+POST http://77.234.215.138:31234/test/stop/{{serviceName}}


### PR DESCRIPTION
- Что именно не работало/падало?
Т.к. запросы шли долго (`averageProcessingTime=PT4.9S`), то `limiter.acquirePermission()` отваливался по таймауту который был выставлен в настройке `RateLimiter`.
- Гипотеза, почему так происходило
Потому-что запросы к клиенту были очень долгие, и другие запросы отваливались по таймауту.
- Что именно добавлено/изменено
Добавил `WindowLimiterInterceptor`, который ограничивает количество потоков, которые могут отправлять запросы
- Почему эти изменения исправляют проблему
По сути, я ограничил количество потоков со стороны приложения. Долгое выполнение запроса на стороннем сервисе влечёт за собой увеличение параллельности запросов, и в этом есть проблема, что есть ограничение у стороннего сервиса на количество параллельных запросов