### PR TITLE
Case 3

### DIFF
--- a/src/main/kotlin/ru/quipy/common/utils/FixedWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/FixedWindowRateLimiter.kt
@@ -141,7 +141,7 @@ fun makeRateLimiter(accountName: String, rate: Int, timeUnit: TimeUnit = TimeUni
     val config = RateLimiterConfig.custom()
         .limitRefreshPeriod(if (timeUnit == TimeUnit.SECONDS) Duration.ofSeconds(1) else Duration.ofMinutes(1))
         .limitForPeriod(rate)
-        .timeoutDuration(Duration.ofMillis(5))
+        .timeoutDuration(Duration.ofSeconds(5))
         .build()
 
     val rateLimiterRegistry = RateLimiterRegistry.of(config)

--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/MetricsInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/MetricsInterceptor.kt
@@ -1,0 +1,22 @@
+package ru.quipy.common.utils.okhttp
+
+import io.micrometer.core.instrument.MeterRegistry
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class MetricsInterceptor(meterRegistry: MeterRegistry) : Interceptor {
+
+    private val parallelRequests: AtomicInteger? = meterRegistry.gauge("parallel_requests", AtomicInteger(0))
+    private val requestsProcessed = meterRegistry.counter("requests_processed")
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        parallelRequests?.getAndIncrement()
+        val response = chain.proceed(chain.request())
+        parallelRequests?.getAndDecrement()
+        requestsProcessed.increment()
+        return response
+    }
+}

--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/RateLimiterInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/RateLimiterInterceptor.kt
@@ -1,0 +1,16 @@
+package ru.quipy.common.utils.okhttp
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class RateLimiterInterceptor(
+    private val limiter: RateLimiter,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (!limiter.acquirePermission()) throw IOException("Timeout from RateLimiter")
+
+        return chain.proceed(chain.request())
+    }
+}

--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/WindowLimiterInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/WindowLimiterInterceptor.kt
@@ -1,0 +1,18 @@
+package ru.quipy.common.utils.okhttp
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.concurrent.Semaphore
+
+class WindowLimiterInterceptor(limit: Int) : Interceptor {
+    private val semaphore: Semaphore = Semaphore(limit, true)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        try {
+            semaphore.acquire()
+            return chain.proceed(chain.request())
+        } finally {
+            semaphore.release()
+        }
+    }
+}

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import ru.quipy.common.utils.okhttp.MetricsInterceptor
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import ru.quipy.payments.logic.*
@@ -36,7 +37,7 @@ class PaymentAccountsConfig {
     lateinit var allowedAccounts: List<String>
 
     @Bean
-    fun accountAdapters(paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>): List<PaymentExternalSystemAdapter> {
+    fun accountAdapters(paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>, metricsInterceptor: MetricsInterceptor): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
             .uri(URI("http://${paymentProviderHostPort}/external/accounts?serviceName=$serviceName&token=$token"))
             .GET()
@@ -57,7 +58,8 @@ class PaymentAccountsConfig {
                     it,
                     paymentService,
                     paymentProviderHostPort,
-                    token
+                    token,
+                    metricsInterceptor
                 )
             }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,6 +7,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.makeRateLimiter
+import ru.quipy.common.utils.okhttp.MetricsInterceptor
 import ru.quipy.common.utils.okhttp.RateLimiterInterceptor
 import ru.quipy.common.utils.okhttp.WindowLimiterInterceptor
 import ru.quipy.core.EventSourcingService
@@ -21,6 +22,7 @@ class PaymentExternalSystemAdapterImpl(
     private val paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
     private val paymentProviderHostPort: String,
     private val token: String,
+    metricsInterceptor: MetricsInterceptor,
 ) : PaymentExternalSystemAdapter {
 
     companion object {
@@ -55,6 +57,7 @@ class PaymentExternalSystemAdapterImpl(
         .Builder()
         .addInterceptor(WindowLimiterInterceptor(parallelRequests))
         .addInterceptor(RateLimiterInterceptor(rateLimiter))
+        .addInterceptor(metricsInterceptor)
         .build()
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -12,4 +12,4 @@ Content-Type: application/json
 
 ### Stop running test to save time and resources
 # @timeout 120
-POST http://localhost:4321/test/stop/"{{serviceName}}"
+POST http://localhost:1234/test/stop/{{serviceName}}

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -16,4 +16,4 @@ Content-Type: application/json
 
 ### Stop running test to save credits
 # @timeout 120
-POST http://77.234.215.138:31234/test/stop/"{{serviceName}}"
+POST http://77.234.215.138:31234/test/stop/{{serviceName}}


### PR DESCRIPTION
Свойства acc-5: PaymentAccountProperties(serviceName=daolana, accountName=acc-5, parallelRequests=5, rateLimitPerSec=3, price=30, averageProcessingTime=PT4.9S, enabled=true)

Сделаем из этих свойств следующие выводы:
1. Один поток в acc-5 обрабатывает запрос за 5 секунд. Получается, что он делает 1/5=0.2 запросов в секунду.
2. Таких потоков у нас 5 штук, то есть мы можем обрабатывать 0.2 * 5 = 1 запросов в секунду. 

При следующих запросах (case-2): rps=2, testCount=100, processingTimeMillis=60000 всё окей, т.к. 100 тестов мы успеем разгрести за 100 секунд. Но при этом из-за того, что количество поступающих запросов выше, чем количество разгребаемых запросов, то количество ждущих своей очереди запросов увеличивается и среднее ожидание запроса тоже увеличивается. Но благодаря маленькому количеству тестов и большому количеству processingTimeMillis, case-2 проходил вполне успешно.

Но в case-3 слишком много тестов, из-за чего вот эта очередь запросов не успевает разгрестись. 

Также добавили метрики, по которым видно, что мы используем все 5 потоков acc-5 и обрабатываем в среднем всего 1 запрос в секунду. 