### PR TITLE
Case 5 2

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -28,7 +28,7 @@ class OrderPayer {
     @Autowired
     private lateinit var paymentService: PaymentService
 
-    private var rateLimiter = LeakingBucketRateLimiter(9, Duration.ofSeconds(1), 230)
+    private var rateLimiter = LeakingBucketRateLimiter(9, Duration.ofSeconds(1), 120)
 
     private val paymentExecutor = ThreadPoolExecutor(
         16,


### PR DESCRIPTION
Добавили rate limiter для входящих запросов.
Во втором тесте мы имеем средний входящий rps 11, но входящая нагрузка волнообразная. Мы уменьшили максимальный размер очереди до 120 по сравнению с 3-им тестом, так как здесь меньше времени на оплату - 13 секунд.
Опирались на 11 * 13 = 143 запроса (теоретически можем обработать за 13 секунд, 11 - rps аккаунта 23) и потом уменьшали пока тесты не будут проходить. В итоге пришли к 120
