### PR TITLE
Case 5 3

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/ErrorHandler.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/ErrorHandler.kt
@@ -1,0 +1,21 @@
+package ru.quipy.apigateway
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import java.util.concurrent.RejectedExecutionException
+
+@ControllerAdvice
+class ErrorHandler {
+
+    @ExceptionHandler
+    fun handleRejectedExecutionException(e: RejectedExecutionException): ResponseEntity<String> {
+        val headers = HttpHeaders()
+        val retryAfterSeconds = 15
+        headers.add("Retry-After", retryAfterSeconds.toString())
+
+        return ResponseEntity("Too many requests", headers, HttpStatus.TOO_MANY_REQUESTS)
+    }
+}

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -28,7 +28,7 @@ class OrderPayer {
     @Autowired
     private lateinit var paymentService: PaymentService
 
-    private var rateLimiter = LeakingBucketRateLimiter(10, Duration.ofSeconds(1), 240)
+    private var rateLimiter = LeakingBucketRateLimiter(9, Duration.ofSeconds(1), 230)
 
     private val paymentExecutor = ThreadPoolExecutor(
         16,

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -28,7 +28,7 @@ class OrderPayer {
     @Autowired
     private lateinit var paymentService: PaymentService
 
-    private var rateLimiter = LeakingBucketRateLimiter(9, Duration.ofSeconds(1), 230)
+    private var rateLimiter = LeakingBucketRateLimiter(33, Duration.ofSeconds(3), 262)
 
     private val paymentExecutor = ThreadPoolExecutor(
         16,

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -15,6 +15,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.RejectedExecutionException
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -61,6 +62,10 @@ class PaymentExternalSystemAdapterImpl(
         .build()
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        if (deadline - now() < requestAverageProcessingTime.toMillis()) {
+            throw RejectedExecutionException()
+        }
+
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()


### PR DESCRIPTION
В этом тесте запросы приходят неравномерно пучками, и в пиковые моменты появлялось слишком много запросов в очереди, часть из них не успевала обработаться за нужное время.

Добавили rate limiter, который отсеивает входящие запросы, использовали Leaking Bucket алгоритм, так как он выравнивает нагрузку. Теперь если лимит превышен, то на запрос возвращается ошибка 429 Too Many Requests.
Так мы не будем добавлять в очередь запрос, который не успеем обработать, и не тратим на него время.

Параметры поставили: rate - 9, максимальный размер очереди - 230.
Изначально поставили rate - 11, так как внешний сервис оплаты для acc-23 имеет rps - 11. Но в таком случае новые токены появляются слишком быстро, и появляются долгождущие запросы. Поэтому поставили rate немного поменьше.
В нашем тесте processingTime - 26 секунд. Когда выставляли размер очереди, то опирались на 11 * 26 = 286 запросов может обработать сервис оплаты за 26 секунд. И потом уменьшали, чтобы все запросы успевали обработаться. Пришли к цифре 230