### PR TITLE
Case 8

### DIFF
--- a/src/main/kotlin/ru/quipy/common/utils/okhttp/MetricsInterceptor.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/okhttp/MetricsInterceptor.kt
@@ -1,20 +1,26 @@
 package ru.quipy.common.utils.okhttp
 
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import okhttp3.Interceptor
 import okhttp3.Response
-import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
-@Component
-class MetricsInterceptor(meterRegistry: MeterRegistry) : Interceptor {
+class MetricsInterceptor(meterRegistry: MeterRegistry, account: String) : Interceptor {
 
     private val parallelRequests: AtomicInteger? = meterRegistry.gauge("parallel_requests", AtomicInteger(0))
     private val requestsProcessed = meterRegistry.counter("requests_processed")
+    val timer: Timer = Timer.builder("account_payment_request_duration")
+        .tag("account", account)
+        .publishPercentileHistogram(true)
+        .register(meterRegistry)
 
     override fun intercept(chain: Interceptor.Chain): Response {
         parallelRequests?.getAndIncrement()
+        val start = System.nanoTime()
         val response = chain.proceed(chain.request())
+        timer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS)
         parallelRequests?.getAndDecrement()
         requestsProcessed.increment()
         return response

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -42,7 +42,6 @@ class PaymentAccountsConfig {
     @Bean
     fun accountAdapters(
         paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
-        metricsInterceptor: MetricsInterceptor,
         meterRegistry: MeterRegistry
     ): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
@@ -66,7 +65,7 @@ class PaymentAccountsConfig {
                     paymentService,
                     paymentProviderHostPort,
                     token,
-                    metricsInterceptor,
+                    MetricsInterceptor(meterRegistry, it.accountName),
                     meterRegistry
                 )
             }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.Response
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.common.utils.okhttp.MetricsInterceptor
@@ -19,7 +22,6 @@ import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.UUID
-import java.util.function.Supplier
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -56,16 +58,13 @@ class PaymentExternalSystemAdapterImpl(
         .callTimeout(Duration.ofSeconds(CALL_TIMEOUT_IN_SECONDS))
         .build()
 
-    val timer = Timer.builder("account_payment_request_duration")
-        .tag("account", accountName)
-        .publishPercentileHistogram(true)
-        .register(meterRegistry)
-
     val retries = Counter.builder("account_payment_request_retries")
         .tag("account", accountName)
         .register(meterRegistry)
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    private val executorScope = CoroutineScope(Dispatchers.IO)
+
+    override suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()
@@ -78,71 +77,12 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        var attempts = 0
-        var successful = false
-        while (attempts < MAX_ATTEMPTS && !successful) {
-            attempts++
-            retries.increment()
-            try {
-                val request = Request.Builder().run {
-                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                    post(emptyBody)
-                }.build()
+        val request = Request.Builder().run {
+            url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+            post(emptyBody)
+        }.build()
 
-                val response = timer.record(Supplier {
-                    client.newCall(request).execute()
-                })!!
-
-                response.use { response ->
-                    val body = try {
-                        mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                    } catch (e: Exception) {
-                        logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                    }
-
-                    logger.info("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, message: ${body.message}, result code: ${response.code}")
-
-                    // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                    // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(
-                            body.result,
-                            now(),
-                            transactionId,
-                            reason = body.message
-                        )
-                    }
-
-                    if (!body.result && body.message == "Temporary error" && deadline - now() > requestAverageProcessingTime.toMillis()) {
-                        logger.warn("[$accountName] Temporary error, attempt $attempts/$MAX_ATTEMPTS, will retry...")
-                    } else {
-                        successful = true
-                    }
-                }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException, is InterruptedIOException -> {
-                        if (attempts < MAX_ATTEMPTS) {
-                            continue
-                        }
-
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                        break
-                    }
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
-                        break
-                    }
-                }
-            }
-        }
+        executeRequestAsync(request, transactionId, paymentId, deadline)
     }
 
     override fun price() = properties.price
@@ -150,6 +90,81 @@ class PaymentExternalSystemAdapterImpl(
     override fun isEnabled() = properties.enabled
 
     override fun name() = properties.accountName
+
+    private suspend fun executeRequestAsync(
+        request: Request, transactionId: UUID, paymentId: UUID, deadline: Long, attempts: Int = 0
+    ) {
+        val deferredResponse = executorScope.async {
+            client.newCall(request).execute()
+        }
+
+        try {
+            val response = deferredResponse.await()
+            processResponse(request, response, transactionId, paymentId, deadline, attempts + 1)
+        } catch (e: Exception) {
+            onFailure(request, e, transactionId, paymentId, deadline, attempts + 1)
+        }
+    }
+
+    private suspend fun onFailure(
+        request: Request, e: Exception, transactionId: UUID, paymentId: UUID, deadline: Long, attempt: Int
+    ) {
+        when (e) {
+            is SocketTimeoutException, is InterruptedIOException -> {
+                logger.error(
+                    "[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e
+                )
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                }
+
+                if (attempt < MAX_ATTEMPTS && deadline - now() > requestAverageProcessingTime.toMillis()) {
+                    retries.increment()
+                    executeRequestAsync(request, transactionId, paymentId, deadline, attempt)
+                }
+            }
+
+            else -> {
+                logger.error(
+                    "[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e
+                )
+                paymentESService.update(paymentId) {
+                    it.logProcessing(false, now(), transactionId, reason = e.message)
+                }
+            }
+        }
+    }
+
+    private suspend fun processResponse(
+        request: Request, response: Response, transactionId: UUID, paymentId: UUID, deadline: Long, attempt: Int
+    ) {
+        response.use {
+            val body = try {
+                mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+            } catch (e: Exception) {
+                logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+            }
+
+            logger.info("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, message: ${body.message}, result code: ${response.code}")
+
+            // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+            // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+            paymentESService.update(paymentId) {
+                it.logProcessing(
+                    body.result, now(), transactionId, reason = body.message
+                )
+            }
+
+            if (!body.result && body.message == "Temporary error") {
+                logger.warn("[$accountName] Temporary error, attempt ${attempt}/$MAX_ATTEMPTS")
+                if (attempt < MAX_ATTEMPTS && deadline - now() > requestAverageProcessingTime.toMillis()) {
+                    retries.increment()
+                    executeRequestAsync(request, transactionId, paymentId, deadline, attempt)
+                }
+            }
+        }
+    }
 }
 
 fun now() = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -7,7 +7,7 @@ interface PaymentService {
     /**
      * Submit payment request to some external service.
      */
-    fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 }
 
 /**
@@ -17,7 +17,7 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    suspend fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 
     fun name(): String
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -12,7 +12,7 @@ class PaymentSystemImpl(
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
     }
 
-    override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override suspend fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
             account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,5 @@ payment.token=${PAYMENT_TOKEN}
 payment.accounts=${PAYMENT_ACCOUNTS:acc-23}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}
 
-ratelimiter.rate=11
-# 330 = 11 * 30
+ratelimiter.rate=100
 ratelimiter.bucket-size=330


### PR DESCRIPTION
Что не работало/падало:
Большая часть тестов падала по таймауту, и количество rps от нас к сервису оплаты было около 30. Хотя входящий rps от тестирующей системы - 100.

Гипотеза, почему так происходило:
У нас при отправке http запросов используются блокирующие вызовы. То есть, если запрос выполняется 0.5 секунд (как в данном кейсе), то и поток виснет на 0.5 секунд. В OrderPayer используется тред пул на 16 потоков. Каждый из них успевает обработать всего 2 запроса в секунду.

Что именно изменено:
Теперь используются асинхронные вызовы.

Почему эти изменения решают проблему:
Так как потоки не блокируются, мы можем посылать и обрабатывать больше запросов.